### PR TITLE
Small fix, `data` instead of `data_object` for whispers

### DIFF
--- a/main.js
+++ b/main.js
@@ -294,7 +294,7 @@ class TwitchPS extends EventEmitter {
           body: message.data.message.data_object.body,
           thread_id: message.data.message.data_object.thread_id,
           sender: {
-            id: message.data.message.data.from_id,
+            id: message.data.message.data_object.from_id,
             username: message.data.message.data_object.tags.login,
             display_name: message.data.message.data_object.tags.display_name,
             color: message.data.message.data_object.tags.color,
@@ -318,7 +318,7 @@ class TwitchPS extends EventEmitter {
           body: message.data.message.data_object.body,
           thread_id: message.data.message.data_object.thread_id,
           sender: {
-            id: message.data.message.data.from_id,
+            id: message.data.message.data_object.from_id,
             username: message.data.message.data_object.tags.login,
             display_name: message.data.message.data_object.tags.display_name,
             color: message.data.message.data_object.tags.color,


### PR DESCRIPTION
Maybe the same is true for `.on('bits')` ?