### PR TITLE
Emiting disconnect event when initial addTopic fails

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,8 +49,13 @@ class TwitchPS extends EventEmitter {
     this._ws = new WebSocket(this._url);
     const self = this;
     this._ws.on('open', () => {
-      self.addTopic(self._init_topics, true);
-      self.emit('connected');
+      self.addTopic(self._init_topics, true)
+        .catch((err) => {
+          self.emit('disconnected');
+        })
+        .then(() => {
+          self.emit('connected');
+        })
     });
     /**
      * MSG TYPES HANDLED:


### PR DESCRIPTION
Currently, it seems like there is no way to know if the initial `addTopic` fails, the user is therefore not able to know if the connection has been successfully established. That would do the trick.